### PR TITLE
fix: mention in message

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -12,7 +12,7 @@ IPFS_CIDS = [
 ]
 
 LEADERBOARD_LINE = "> -> %s: %s points\n"
-MAIN_PINS_ANNOUNCE = """||@Attendance||
+MAIN_PINS_ANNOUNCE = """||<@&1082653719310639194>||
 ```fix
 Attendance codes are available!
 ```


### PR DESCRIPTION
I just fix the mention in message in `/moodle_pins`.
It was tested.